### PR TITLE
Increase ID data range

### DIFF
--- a/bundled/openapi.yaml
+++ b/bundled/openapi.yaml
@@ -511,7 +511,7 @@ components:
           example: Dürkheimer Michelsberg
         station_id:
           type: integer
-          format: int32
+          format: int64
           description: The numeric ID of the station that makes Forecasts for a group of Fields.
           example: 4711
         number:

--- a/bundled/openapi.yaml
+++ b/bundled/openapi.yaml
@@ -363,7 +363,7 @@ components:
               example: 2000
             row_number:
               type: integer
-              format: int64
+              format: int32
               description: Number of the row of the Plant
               example: 2
     PlantPatch:

--- a/bundled/openapi.yaml
+++ b/bundled/openapi.yaml
@@ -405,7 +405,7 @@ components:
           example: 2000
         row_number:
           type: integer
-          format: int64
+          format: int32
           description: Number of the row of the Plant
           example: 2
     PlanterRun:

--- a/parameters/FieldId.yaml
+++ b/parameters/FieldId.yaml
@@ -4,5 +4,5 @@ required: true
 description: The numeric ID of the field
 schema:
   type: integer
-  format: int32
+  format: int64
   example: 4711

--- a/parameters/ForecastId.yaml
+++ b/parameters/ForecastId.yaml
@@ -4,5 +4,5 @@ required: true
 description: The numeric ID of the forecast
 schema:
   type: integer
-  format: int32
+  format: int64
   example: 4711

--- a/parameters/HarvestTaskId.yaml
+++ b/parameters/HarvestTaskId.yaml
@@ -4,5 +4,5 @@ required: true
 description: The numeric ID of the Harvest Task
 schema:
   type: integer
-  format: int32
+  format: int64
   example: 4711

--- a/parameters/PlantId.yaml
+++ b/parameters/PlantId.yaml
@@ -4,5 +4,5 @@ required: true
 description: The numeric ID of the plant
 schema:
   type: integer
-  format: int32
+  format: int64
   example: 4711

--- a/parameters/PlanterRunId.yaml
+++ b/parameters/PlanterRunId.yaml
@@ -4,5 +4,5 @@ required: true
 description: The numeric ID of the planter run
 schema:
   type: integer
-  format: int32
+  format: int64
   example: 4711

--- a/parameters/QualityMeasurementId.yaml
+++ b/parameters/QualityMeasurementId.yaml
@@ -4,5 +4,5 @@ required: true
 description: The numeric ID of the quality measurement
 schema:
   type: integer
-  format: int32
+  format: int64
   example: 4711

--- a/parameters/SprayTaskId.yaml
+++ b/parameters/SprayTaskId.yaml
@@ -4,5 +4,5 @@ required: true
 description: The numeric ID of the Spray Task
 schema:
   type: integer
-  format: int32
+  format: int64
   example: 4711

--- a/parameters/TerrainId.yaml
+++ b/parameters/TerrainId.yaml
@@ -4,5 +4,5 @@ required: true
 description: The numeric ID of the terrain model
 schema:
   type: integer
-  format: int32
+  format: int64
   example: 4711

--- a/path/field_index.yaml
+++ b/path/field_index.yaml
@@ -56,7 +56,7 @@ post:
             properties:
               id:
                 type: integer
-                format: int32
+                format: int64
                 description: Numeric ID of the created Field.
       links:
         # GET /field

--- a/path/forecast_index.yaml
+++ b/path/forecast_index.yaml
@@ -56,7 +56,7 @@ post:
             properties:
               id:
                 type: integer
-                format: int32
+                format: int64
                 description: Numeric ID of the created Forecast.
       links:
         # GET /forecast

--- a/path/harvest_complete_index.yaml
+++ b/path/harvest_complete_index.yaml
@@ -61,7 +61,7 @@ post:
             properties:
               id:
                 type: integer
-                format: int32
+                format: int64
                 description: Numeric ID of the created Harvest Task.
       links:
         # GET /harvest/complete

--- a/path/harvest_task_index.yaml
+++ b/path/harvest_task_index.yaml
@@ -60,7 +60,7 @@ post:
             properties:
               id:
                 type: integer
-                format: int32
+                format: int64
                 description: Numeric ID of the created Harvest Task.
       links:
         # GET /harvest/task

--- a/path/plant_index.yaml
+++ b/path/plant_index.yaml
@@ -82,7 +82,7 @@ post:
             properties:
               id:
                 type: integer
-                format: int32
+                format: int64
                 description: Numeric ID of the created Plant.
       links:
         # GET /field/{FieldId}/planter/{PlanterRunId}/plant

--- a/path/planter_index.yaml
+++ b/path/planter_index.yaml
@@ -71,7 +71,7 @@ post:
             properties:
               id:
                 type: integer
-                format: int32
+                format: int64
                 description: Numeric ID of the created Planter Run.
       links:
         # GET /field/{FieldId}/planter

--- a/path/quality_measurement_index.yaml
+++ b/path/quality_measurement_index.yaml
@@ -93,7 +93,7 @@ post:
             properties:
               id:
                 type: integer
-                format: int32
+                format: int64
                 description: Numeric ID of the created Quality Measurement.
       links:
         # GET /field/{FieldId}/planter/{PlanterRunId}/plant/{PlantId}/quality_measurement

--- a/path/spray_complete_index.yaml
+++ b/path/spray_complete_index.yaml
@@ -61,7 +61,7 @@ post:
             properties:
               id:
                 type: integer
-                format: int32
+                format: int64
                 description: Numeric ID of the created Spray Task.
       links:
         # GET /spray/complete

--- a/path/spray_task_index.yaml
+++ b/path/spray_task_index.yaml
@@ -60,7 +60,7 @@ post:
             properties:
               id:
                 type: integer
-                format: int32
+                format: int64
                 description: Numeric ID of the created Spray Task.
       links:
         # GET /spray/task

--- a/schemas/Field.yaml
+++ b/schemas/Field.yaml
@@ -25,7 +25,7 @@ properties:
     properties:
       id:
         type: integer
-        format: int32
+        format: int64
         description: The numeric ID of the field
         example: 4711
       name:
@@ -34,7 +34,7 @@ properties:
         example: Dürkheimer Michelsberg
       station_id:
         type: integer
-        format: int32
+        format: int64
         description: The numeric ID of the station that makes Forecasts for a group of Fields.
         example: 4711
       number:

--- a/schemas/FieldPatch.yaml
+++ b/schemas/FieldPatch.yaml
@@ -6,7 +6,7 @@ properties:
     example: Dürkheimer Michelsberg
   station_id:
     type: integer
-    format: int32
+    format: int64
     description: The numeric ID of the station that makes Forecasts for a group of Fields.
     example: 4711
   number:

--- a/schemas/Forecast.yaml
+++ b/schemas/Forecast.yaml
@@ -14,17 +14,17 @@ required:
 properties:
   id:
     type: integer
-    format: int32
+    format: int64
     description: The numeric ID of the Forecast
     example: 4711
   group_id:
     type: integer
-    format: int32
+    format: int64
     description: Notice. This information will soon no longer be used and sent along!
     example: 1
   station_id:
     type: integer
-    format: int32
+    format: int64
     description: The numeric ID of the station that makes Forecasts for a group of Fields.
     example: 4711
   station:
@@ -35,12 +35,12 @@ properties:
     type: array
     items:
       type: integer
-      format: int32
+      format: int64
     description: An array containing the IDs of the Fields for which the Forecast is.
     example: [4711, 815]
   model_id:
     type: integer
-    format: int32
+    format: int64
     description: The numeric ID of the model
     example: 17
   model:

--- a/schemas/ForecastMeasurement.yaml
+++ b/schemas/ForecastMeasurement.yaml
@@ -5,7 +5,7 @@ required:
 properties:
   id:
     type: integer
-    format: int32
+    format: int64
     description: The numeric ID of the Measurement
     example: 4711
   time:

--- a/schemas/Harvest.yaml
+++ b/schemas/Harvest.yaml
@@ -30,7 +30,7 @@ properties:
     properties:
       task_id:
         type: integer
-        format: int32
+        format: int64
         description: The numeric ID of the Harvest Task
         example: 4711
       task_name:

--- a/schemas/HarvestOrTask.yaml
+++ b/schemas/HarvestOrTask.yaml
@@ -33,7 +33,7 @@ properties:
     properties:
       task_id:
         type: integer
-        format: int32
+        format: int64
         description: The numeric ID of the Harvest Task
         example: 4711
       task_name:

--- a/schemas/HarvestTask.yaml
+++ b/schemas/HarvestTask.yaml
@@ -26,7 +26,7 @@ properties:
     properties:
       task_id:
         type: integer
-        format: int32
+        format: int64
         description: The numeric ID of the Harvest Task
         example: 4711
       task_name:

--- a/schemas/Plant.yaml
+++ b/schemas/Plant.yaml
@@ -68,6 +68,6 @@ properties:
         example: 2000
       row_number:
         type: integer
-        format: int64
+        format: int32
         description: Number of the row of the Plant
         example: 2

--- a/schemas/Plant.yaml
+++ b/schemas/Plant.yaml
@@ -28,7 +28,7 @@ properties:
     properties:
       id:
         type: integer
-        format: int32
+        format: int64
         description: The numeric ID of the Plant
         example: 4711
       import_key:
@@ -68,6 +68,6 @@ properties:
         example: 2000
       row_number:
         type: integer
-        format: int32
+        format: int64
         description: Number of the row of the Plant
         example: 2

--- a/schemas/PlantPatch.yaml
+++ b/schemas/PlantPatch.yaml
@@ -37,6 +37,6 @@ properties:
     example: 2000
   row_number:
     type: integer
-    format: int32
+    format: int64
     description: Number of the row of the Plant
     example: 2

--- a/schemas/PlantPatch.yaml
+++ b/schemas/PlantPatch.yaml
@@ -37,6 +37,6 @@ properties:
     example: 2000
   row_number:
     type: integer
-    format: int64
+    format: int32
     description: Number of the row of the Plant
     example: 2

--- a/schemas/PlanterRun.yaml
+++ b/schemas/PlanterRun.yaml
@@ -28,21 +28,21 @@ properties:
     properties:
       id:
         type: integer
-        format: int32
+        format: int64
         description: The numeric ID of the Planter Run
         example: 4711
       user_id:
         type: integer
-        format: int32
+        format: int64
         description: The numeric ID of the User who planted
         example: 815
       terminal_id:
         type: integer
-        format: int32
+        format: int64
         description: The numeric ID of the Terminal of the Machine that planted
         example: 42
       field_id:
         type: integer
-        format: int32
+        format: int64
         description: The numeric ID of the Field on which the Planter Run is performed.
         example: 4711

--- a/schemas/QualityMeasurement.yaml
+++ b/schemas/QualityMeasurement.yaml
@@ -28,12 +28,12 @@ properties:
     properties:
       id:
         type: integer
-        format: int32
+        format: int64
         description: The numeric ID of the Quality Measurement
         example: 4711
       plant_id:
         type: integer
-        format: int32
+        format: int64
         description: The numeric ID of the Plant
         example: 815
       timestamp:

--- a/schemas/SprayTask.yaml
+++ b/schemas/SprayTask.yaml
@@ -27,7 +27,7 @@ properties:
     properties:
       task_id:
         type: integer
-        format: int32
+        format: int64
         description: The numeric ID of the Harvest Task
         example: 4711
       task_name:

--- a/schemas/Terrain.yaml
+++ b/schemas/Terrain.yaml
@@ -7,7 +7,7 @@ required:
 properties:
   id:
     type: integer
-    format: int32
+    format: int64
   type:
     type: string
     enum:
@@ -24,4 +24,4 @@ properties:
         type: string
       field_id:
         type: integer
-        format: int32
+        format: int64


### PR DESCRIPTION
The current ID data type of `int32` is not big enough to store some production data.
By increasing it to `int64` this problem should be solved